### PR TITLE
Fixing issue with define-constant throwing error

### DIFF
--- a/cl-telegram-bot.asd
+++ b/cl-telegram-bot.asd
@@ -2,7 +2,7 @@
   :description "Telegram Bot API"
   :author "Rei <https://github.com/sovietspaceship>"
   :license "MIT"
-  :depends-on (#:cl-json #:drakma)
+  :depends-on (#:cl-json #:drakma #:alexandria)
   :serial t
   :components ((:file "package")
                (:file "cl-telegram-bot")))

--- a/cl-telegram-bot.lisp
+++ b/cl-telegram-bot.lisp
@@ -24,7 +24,7 @@
 
 (in-package :cl-telegram-bot)
 
-(define-constant +http-ok+ 200 :test #'=)
+(alexandria:define-constant +http-ok+ 200 :test #'=)
 
 (defclass bot ()
   ((id


### PR DESCRIPTION
For some reason `define-constant` on its own didn't work for me. This is something I did that seems to resolve this (well, at least it compiled).