### PR TITLE
Treat bad response status as error

### DIFF
--- a/cl-telegram-bot.lisp
+++ b/cl-telegram-bot.lisp
@@ -71,12 +71,18 @@
 
 (defun make-request (b name options &key (streamp nil))
   "Perform HTTP request to 'name API method with 'options JSON-encoded object."
-  (drakma:http-request
-   (concatenate 'string (endpoint b) name)
-   :method :post
-   :want-stream streamp
-   :content-type "application/json"
-   :content (json:encode-json-alist-to-string options)))
+  (let* ((results (multiple-value-list
+                   (drakma:http-request
+                    (concatenate 'string (endpoint b) name)
+                    :method :post
+                    :want-stream streamp
+                    :content-type "application/json"
+                    :content (json:encode-json-alist-to-string options))))
+         (status (cadr results))
+         (reason (car (last results))))
+    (when (<= 400 status 599)
+      (error 'request-error :what (format nil "request to ~A returned ~A (~A)" name status reason)))
+    (apply 'values results)))
 
 (defun access (update &rest args)
   "Access update field. update.first.second. ... => (access update 'first 'second ...). Nil if unbound."
@@ -115,7 +121,9 @@
   (decode (map 'string #'code-char object)))
 
 (define-condition request-error (error)
-  ((what :initarg :what :reader what)))
+  ((what :initarg :what :reader what))
+  (:report (lambda (condition stream)
+             (format stream "Request error: ~A" (what condition)))))
 
 (defmacro find-json-symbol (sym)
   `(find-symbol (symbol-name ,sym) json:*json-symbols-package*))


### PR DESCRIPTION
Ran into issue when sending-request would return, but nothing send – only to find out after long debug that issue was with payload being too big. To avoid someone else running into this would suggest adding guard against bad status code around drakma call. What do you think?